### PR TITLE
Fixed background color clipping on wide screen resolutions

### DIFF
--- a/themes/sass/style.sass
+++ b/themes/sass/style.sass
@@ -11,6 +11,7 @@ html
     background-color: $dark-grey
     font-family: $font
     font-size: 16px
+    min-height: 100%
 
 body
     font-size: $body-size


### PR DESCRIPTION
Pages smaller than 100% height resulted in tiling/clipping of background gradient, creating a jarring effect. Not sure if this was intentional but if not, easy 1-line fix.

Before fix (1920x1080):
![2018-08-03-142227_1920x1043_scrot](https://user-images.githubusercontent.com/20714410/43659351-c22e41fa-9729-11e8-9a8e-28c7cb0e3eb9.png)

After fix (1920x1080):
![2018-08-03-142301_1920x1043_scrot](https://user-images.githubusercontent.com/20714410/43659357-c6b37be6-9729-11e8-98eb-3412f8fe6efe.png)
